### PR TITLE
Cut extra `into` typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # truffle-artifactor (formerly ether-pudding)
 
-This package saves contract artifacts into into Javascript files that can be `require`'d. i.e.,
+This package saves contract artifacts into Javascript files that can be `require`'d. i.e.,
 
 ```javascript
 var artifactor = require("truffle-artifactor");


### PR DESCRIPTION
The word `into` was repeated accidentally. This commit removes the additional word.